### PR TITLE
fix: use the GITHUB_ACTION_PATH env to run the script

### DIFF
--- a/action.yml
+++ b/action.yml
@@ -72,7 +72,7 @@ runs:
         REF_NAME: ${{ github.ref_name }}
         OVERRIDE_JOB_STATUS: ${{ inputs.OVERRIDE_JOB_STATUS }}
         EXTRA_MESSAGE: ${{ inputs.extra_message }}
-      run: python generate_slack_payload.py
+      run: python "${GITHUB_ACTION_PATH}/generate_slack_payload.py"
 
     - uses: slackapi/slack-github-action@v1.23.0
       with:


### PR DESCRIPTION
The current working directory may not be the GitHub action one.

We must use this environment variable to locate our script