### PR TITLE
ci(dependabot): require 7-day cooldown for dependency upgrades

### DIFF
--- a/.github/dependabot.yml
+++ b/.github/dependabot.yml
@@ -7,6 +7,8 @@ updates:
       time: "08:00"
       timezone: Europe/Paris
     open-pull-requests-limit: 10
+    cooldown:
+      default-days: 7
   - package-ecosystem: "github-actions"
     directory: "/"
     schedule:
@@ -14,3 +16,5 @@ updates:
       time: "08:00"
       timezone: Europe/Paris
     open-pull-requests-limit: 10
+    cooldown:
+      default-days: 7


### PR DESCRIPTION
Mitigate supply chain attacks by waiting 7 days before adopting any new dependency release. Most compromised packages (Shai-Hulud, ua-parser-js, eslint-config-prettier, etc.) are detected and yanked within hours-to-days of publication, so a release-age delay catches the overwhelming majority of malicious releases before they hit our lockfiles.

Security updates bypass this delay automatically — Dependabot's `cooldown` option is documented as "only available for version updates, not security updates", so CVE fixes still ship without waiting.

Mirrors the equivalent change in the Mergify monorepo (which uses Renovate's `minimumReleaseAge`): Mergifyio/mergify#31013.