### PR TITLE
ci: fix yamllint and actionlint failures

### DIFF
--- a/.github/workflows/ci.yaml
+++ b/.github/workflows/ci.yaml
@@ -17,19 +17,19 @@ jobs:
     runs-on: ubuntu-24.04
     steps:
       - name: Checkout 🛎️
-        uses: actions/checkout@de0fac2e4500dabe0009e67214ff5f5447ce83dd # v6.0.2
+        uses: actions/checkout@de0fac2e4500dabe0009e67214ff5f5447ce83dd  # v6.0.2
         with:
           fetch-depth: 0
 
       - name: Setup Python 🔧
-        uses: actions/setup-python@a309ff8b426b58ec0e2a45f0f869d46889d02405 # v6.2.0
+        uses: actions/setup-python@a309ff8b426b58ec0e2a45f0f869d46889d02405  # v6.2.0
         with:
           python-version: 3.11.2
 
       - name: Download actionlint
         id: get_actionlint
         # yamllint disable-line rule:line-length
-        run: bash <(curl https://raw.githubusercontent.com/rhysd/actionlint/main/scripts/download-actionlint.bash) 1.6.15
+        run: bash <(curl https://raw.githubusercontent.com/rhysd/actionlint/main/scripts/download-actionlint.bash) 1.7.12
 
       - name: Test 🔍
         run: |
@@ -44,7 +44,7 @@ jobs:
     runs-on: ubuntu-latest
     steps:
       - name: Checkout 🛎️
-        uses: actions/checkout@de0fac2e4500dabe0009e67214ff5f5447ce83dd # v6.0.2
+        uses: actions/checkout@de0fac2e4500dabe0009e67214ff5f5447ce83dd  # v6.0.2
       - name: Report status 🔍
         if: always()
         uses: ./
@@ -57,7 +57,7 @@ jobs:
     runs-on: ubuntu-latest
     steps:
       - name: Checkout 🛎️
-        uses: actions/checkout@de0fac2e4500dabe0009e67214ff5f5447ce83dd # v6.0.2
+        uses: actions/checkout@de0fac2e4500dabe0009e67214ff5f5447ce83dd  # v6.0.2
       - name: Report status 🔍
         if: always()
         uses: ./
@@ -78,7 +78,7 @@ jobs:
     runs-on: ubuntu-latest
     steps:
       - name: Checkout 🛎️
-        uses: actions/checkout@de0fac2e4500dabe0009e67214ff5f5447ce83dd # v6.0.2
+        uses: actions/checkout@de0fac2e4500dabe0009e67214ff5f5447ce83dd  # v6.0.2
       - name: Report status 🔍
         if: always()
         uses: ./

--- a/action.yml
+++ b/action.yml
@@ -35,7 +35,7 @@ runs:
   steps:
     - name: Fetch job check run information
       id: fetch-check-run
-      uses: actions/github-script@3a2844b7e9c422d3c10d287c895573f7108da1b3 # v9.0.0
+      uses: actions/github-script@3a2844b7e9c422d3c10d287c895573f7108da1b3  # v9.0.0
       with:
         result-encoding: string
         script: |
@@ -74,13 +74,13 @@ runs:
         EXTRA_MESSAGE: ${{ inputs.extra_message }}
       run: python "${GITHUB_ACTION_PATH}/generate_slack_payload.py"
 
-    - uses: slackapi/slack-github-action@45a88b9581bfab2566dc881e2cd66d334e621e2c # v3.0.3
+    - uses: slackapi/slack-github-action@45a88b9581bfab2566dc881e2cd66d334e621e2c  # v3.0.3
       with:
         webhook: ${{ inputs.SLACK_WEBHOOK_URL }}
         webhook-type: incoming-webhook
         payload: ${{ steps.report-status.outputs.SLACK_PAYLOAD }}
 
-    - uses: slackapi/slack-github-action@45a88b9581bfab2566dc881e2cd66d334e621e2c # v3.0.3
+    - uses: slackapi/slack-github-action@45a88b9581bfab2566dc881e2cd66d334e621e2c  # v3.0.3
       if: ${{ job.status == 'failure' && inputs.FAILURE_ONLY_SLACK_WEBHOOK_URL != '' }}
       with:
         webhook: ${{ inputs.FAILURE_ONLY_SLACK_WEBHOOK_URL }}


### PR DESCRIPTION
yamllint expects 2 spaces between code and inline comment markers but several SHA-pinned action references had only 1. The `linters` job runs `yamllint .` across the repo and fails on these pre-existing violations whenever any YAML file is touched.

actionlint was pinned to 1.6.15 (Aug 2022) which predates the `ubuntu-24.04` runner label; ci.yaml uses `ubuntu-24.04` and was flagged as an unknown runner. Bumped to 1.7.12 (latest as of today).

Affected files:
- `action.yml` lines 38, 77, 83 (yamllint)
- `.github/workflows/ci.yaml` lines 20, 25, 32, 47, 60, 81 (yamllint + actionlint)

Required so that #22 (cooldown PR) can pass CI.