### PR TITLE
ci: fix linters and migrate mergify config

### DIFF
--- a/.github/workflows/ci.yaml
+++ b/.github/workflows/ci.yaml
@@ -17,19 +17,19 @@ jobs:
     runs-on: ubuntu-24.04
     steps:
       - name: Checkout 🛎️
-        uses: actions/checkout@de0fac2e4500dabe0009e67214ff5f5447ce83dd # v6.0.2
+        uses: actions/checkout@de0fac2e4500dabe0009e67214ff5f5447ce83dd  # v6.0.2
         with:
           fetch-depth: 0
 
       - name: Setup Python 🔧
-        uses: actions/setup-python@a309ff8b426b58ec0e2a45f0f869d46889d02405 # v6.2.0
+        uses: actions/setup-python@a309ff8b426b58ec0e2a45f0f869d46889d02405  # v6.2.0
         with:
           python-version: 3.11.2
 
       - name: Download actionlint
         id: get_actionlint
         # yamllint disable-line rule:line-length
-        run: bash <(curl https://raw.githubusercontent.com/rhysd/actionlint/main/scripts/download-actionlint.bash) 1.6.15
+        run: bash <(curl https://raw.githubusercontent.com/rhysd/actionlint/main/scripts/download-actionlint.bash) 1.7.12
 
       - name: Test 🔍
         run: |
@@ -44,7 +44,7 @@ jobs:
     runs-on: ubuntu-latest
     steps:
       - name: Checkout 🛎️
-        uses: actions/checkout@de0fac2e4500dabe0009e67214ff5f5447ce83dd # v6.0.2
+        uses: actions/checkout@de0fac2e4500dabe0009e67214ff5f5447ce83dd  # v6.0.2
       - name: Report status 🔍
         if: always()
         uses: ./
@@ -57,7 +57,7 @@ jobs:
     runs-on: ubuntu-latest
     steps:
       - name: Checkout 🛎️
-        uses: actions/checkout@de0fac2e4500dabe0009e67214ff5f5447ce83dd # v6.0.2
+        uses: actions/checkout@de0fac2e4500dabe0009e67214ff5f5447ce83dd  # v6.0.2
       - name: Report status 🔍
         if: always()
         uses: ./
@@ -78,7 +78,7 @@ jobs:
     runs-on: ubuntu-latest
     steps:
       - name: Checkout 🛎️
-        uses: actions/checkout@de0fac2e4500dabe0009e67214ff5f5447ce83dd # v6.0.2
+        uses: actions/checkout@de0fac2e4500dabe0009e67214ff5f5447ce83dd  # v6.0.2
       - name: Report status 🔍
         if: always()
         uses: ./

--- a/.mergify.yml
+++ b/.mergify.yml
@@ -19,8 +19,7 @@ queue_rules:
     batch_size: 7
     batch_max_wait_time: 5min
     queue_branch_merge_method: fast-forward
-    disallow_checks_interruption_from_queues:
-      - default
+    merge_method: merge
 
 pull_request_rules:
   - name: automatic merge for hotfix
@@ -75,7 +74,6 @@ pull_request_rules:
     actions:
       queue:
         name: lowprio
-        method: merge
 
   - name: automatic merge from trivy
     conditions:
@@ -89,8 +87,6 @@ pull_request_rules:
     actions:
       queue:
         name: lowprio
-        commit_message_template:
-        method: merge
 
   - name: automatic merge from dependabot
     conditions:
@@ -102,8 +98,6 @@ pull_request_rules:
     actions:
       queue:
         name: lowprio
-        method: merge
-        commit_message_template:
 
   - name: request review
     conditions:

--- a/action.yml
+++ b/action.yml
@@ -35,7 +35,7 @@ runs:
   steps:
     - name: Fetch job check run information
       id: fetch-check-run
-      uses: actions/github-script@3a2844b7e9c422d3c10d287c895573f7108da1b3 # v9.0.0
+      uses: actions/github-script@3a2844b7e9c422d3c10d287c895573f7108da1b3  # v9.0.0
       with:
         result-encoding: string
         script: |
@@ -74,13 +74,13 @@ runs:
         EXTRA_MESSAGE: ${{ inputs.extra_message }}
       run: python "${GITHUB_ACTION_PATH}/generate_slack_payload.py"
 
-    - uses: slackapi/slack-github-action@45a88b9581bfab2566dc881e2cd66d334e621e2c # v3.0.3
+    - uses: slackapi/slack-github-action@45a88b9581bfab2566dc881e2cd66d334e621e2c  # v3.0.3
       with:
         webhook: ${{ inputs.SLACK_WEBHOOK_URL }}
         webhook-type: incoming-webhook
         payload: ${{ steps.report-status.outputs.SLACK_PAYLOAD }}
 
-    - uses: slackapi/slack-github-action@45a88b9581bfab2566dc881e2cd66d334e621e2c # v3.0.3
+    - uses: slackapi/slack-github-action@45a88b9581bfab2566dc881e2cd66d334e621e2c  # v3.0.3
       if: ${{ job.status == 'failure' && inputs.FAILURE_ONLY_SLACK_WEBHOOK_URL != '' }}
       with:
         webhook: ${{ inputs.FAILURE_ONLY_SLACK_WEBHOOK_URL }}


### PR DESCRIPTION
Bundles three pre-existing main-branch CI issues that block every PR (including #22, the renovate/dependabot 7-day cooldown PR):

### 1. yamllint comment-spacing
The `linters` job runs `yamllint .` which requires 2 spaces between code and inline comment markers; several SHA-pinned action references had only 1.

**Fixed:** `action.yml` lines 38, 77, 83; `.github/workflows/ci.yaml` lines 20, 25, 47, 60, 81.

### 2. actionlint pinned to 1.6.15
1.6.15 (Aug 2022) predates the `ubuntu-24.04` runner label, so actionlint flagged `ci.yaml`'s `runs-on: ubuntu-24.04` as unknown. Bumped to 1.7.12 (latest stable).

### 3. .mergify.yml schema migration
Mergify removed/relocated several fields. The `Summary` and `Mergify Merge Queue` checks were failing with *"Extra inputs are not permitted"*:

- `method` was removed from `actions.queue` — the merge method is now declared once on the queue rule via `merge_method`. All three rules that used `method: merge` point to the `lowprio` queue, so we set `merge_method: merge` on that queue rule (equivalent behavior, no per-rule override).
- `commit_message_template` was removed from `actions.queue`. The trivy and dependabot rules had empty overrides (`commit_message_template:` with no value) — dropped as no-ops.
- `disallow_checks_interruption_from_queues` on the `lowprio` queue rule is no longer a valid field; dropped. The modern equivalent for that semantic is queue priorities.

The Mergify `Configuration changed` check on the previous push of this branch already confirmed the new config validates successfully.

### Note
The `Summary` / `Mergify Merge Queue` failures on this PR are expected and will clear once it lands — those checks evaluate against the base branch's config, which is what we're fixing here.

---

Supersedes #23 (yamllint+actionlint fix, now bundled here). Required for #22 (cooldown PR) to be mergeable.